### PR TITLE
Fix problem with event messages that require zero string inserts.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -7,7 +7,7 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/andrewkroh/sys/windows/svc/eventlog",
-			"Rev": "0a5ae398184d4d7b2fcc1a2c0af6f76f0558fd9f"
+			"Rev": "287798fe3e430efeb9318b95ff52353aaa2b59b1"
 		},
 		{
 			"ImportPath": "github.com/elastic/libbeat/beat",

--- a/Godeps/_workspace/src/github.com/andrewkroh/sys/windows/svc/eventlog/log.go
+++ b/Godeps/_workspace/src/github.com/andrewkroh/sys/windows/svc/eventlog/log.go
@@ -55,7 +55,11 @@ func (l *Log) Report(etype uint16, eid uint32, msgs []string) error {
 	for _, msg := range msgs {
 		msgPtrs = append(msgPtrs, syscall.StringToUTF16Ptr(msg))
 	}
-	return windows.ReportEvent(l.Handle, etype, 0, eid, 0, uint16(len(msgPtrs)), 0, &msgPtrs[0], nil)
+	var ptr **uint16
+	if len(msgPtrs) > 0 {
+		ptr = &msgPtrs[0]
+	}
+	return windows.ReportEvent(l.Handle, etype, 0, eid, 0, uint16(len(msgPtrs)), 0, ptr, nil)
 }
 
 // Success writes a success event msg with event id eid to the end of event log l.

--- a/eventlog/eventlog_windows.go
+++ b/eventlog/eventlog_windows.go
@@ -234,27 +234,20 @@ func (el *eventLog) formatMessage(
 	stringInserts, stringInsertPtrs, err := getStrings(event, buf)
 	if err != nil {
 		logp.Warn("%s Failed to get string inserts for "+
-			"parameterized message. event=%v, %v", el.logPrefix, event, err)
+			"parameterized message. eventID=%d, recordNumber=%d, %v",
+			el.logPrefix, event.eventID, event.recordNumber, err)
 		return "", err
 	}
-	detailf("%s eventID=%d, recordNumber=%d, String inserts are [%s]. ",
-		el.logPrefix, event.eventID, event.recordNumber,
-		strings.Join(stringInserts, ","))
+	detailf("%s String inserts are [%s]. eventID=%d, recordNumber=%d",
+		el.logPrefix, strings.Join(stringInserts, ","), event.eventID,
+		event.recordNumber)
 
-	var handles []Handle
 	var addr *uintptr
 	if stringInsertPtrs != nil && len(stringInsertPtrs) > 0 {
 		addr = &stringInsertPtrs[0]
-
-		handles = el.handles.get(lr.SourceName)
-		if handles == nil || len(handles) == 0 {
-			detailf("%s Could not get any handles to event message files for "+
-				"sourceName=%s, handles=%v", el.logPrefix, lr.SourceName, handles)
-			message := fmt.Sprintf(noMessageFile, lr.EventID, lr.SourceName,
-				strings.Join(stringInserts, ", "))
-			return message, nil
-		}
 	}
+
+	handles := el.handles.get(lr.SourceName)
 
 	var message string
 	for _, handle := range handles {


### PR DESCRIPTION
The message string wasn't being loaded from the DLL/EXE message file because the code previously assumed that when it received zero string inserts (`event.numStrings=0`) that it had failed to load the message.