### PR TITLE
Adding checkpoint for persisting event log state between restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ _testmain.go
 *.out
 *.log
 *.bak
+*.winlogbeat.yaml
 etc/*.dev.yml
 
 cover/

--- a/checkpoint/checkpoint.go
+++ b/checkpoint/checkpoint.go
@@ -1,0 +1,240 @@
+// Package checkpoint persists event log state information to disk so that
+// event log monitoring can resume from the last read event in the case of a
+// restart or unexpected interruption.
+package checkpoint
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"io/ioutil"
+
+	"github.com/elastic/libbeat/logp"
+	"gopkg.in/yaml.v2"
+)
+
+// Checkpoint persists event log state information to disk.
+type Checkpoint struct {
+	wg            sync.WaitGroup // WaitGroup used to wait on the shutdown of the checkpoint worker.
+	done          chan struct{}  // Channel for shutting down the checkpoint worker.
+	once          sync.Once      // Used to guarantee shutdown happens once.
+	file          string         // File where the state is persisted.
+	numUpdates    int            // Number of updates received since last persisting to disk.
+	maxUpdates    int            // Maximum number of updates to buffer before persisting to disk.
+	flushInterval time.Duration  // Maximum time interval that can pass before persisting to disk.
+	sort          []string       // Slice used for sorting states map (store to save on mallocs).
+
+	lock   sync.RWMutex
+	states map[string]EventLogState
+
+	save chan EventLogState
+}
+
+// PersistedState represents the format of the data persisted to disk.
+type PersistedState struct {
+	UpdateTime time.Time       `yaml:"update_time"`
+	States     []EventLogState `yaml:"event_logs"`
+}
+
+// EventLogState represents the state of an individual event log.
+type EventLogState struct {
+	Name         string    `yaml:"name"`
+	RecordNumber uint32    `yaml:"record_number"`
+	Timestamp    time.Time `yaml:"timestamp"`
+}
+
+// NewCheckpoint creates and returns a new Checkpoint. This method loads state
+// information from disk if it exists and starts a goroutine for persisting
+// state information to disk. Shutdown should be called when finished to
+// guarantee any in-memory state information is flushed to disk.
+//
+// file is the name of the file where event log state is persisted as YAML.
+// maxUpdates is the maximum number of updates checkpoint will accept before
+// triggering a flush to disk. interval is maximum amount of time that can
+// pass since the last flush before triggering a flush to disk (minimum value
+// is 1s).
+func NewCheckpoint(file string, maxUpdates int, interval time.Duration) (*Checkpoint, error) {
+	c := &Checkpoint{
+		done:          make(chan struct{}),
+		file:          file,
+		maxUpdates:    maxUpdates,
+		flushInterval: interval,
+		sort:          make([]string, 0, 10),
+		states:        make(map[string]EventLogState),
+		save:          make(chan EventLogState, 1),
+	}
+
+	// Minimum batch size.
+	if c.maxUpdates < 1 {
+		c.maxUpdates = 1
+	}
+
+	// Minimum flush interval.
+	if c.flushInterval < time.Second {
+		c.flushInterval = time.Second
+	}
+
+	// Read existing state information:
+	ps, err := c.read()
+	if err != nil {
+		return nil, err
+	}
+
+	if ps != nil {
+		for _, state := range ps.States {
+			c.states[state.Name] = state
+		}
+	}
+
+	c.wg.Add(1)
+	go c.run()
+	return c, nil
+}
+
+// run is worker loop that reads incoming state information from the save
+// channel and persists it when the number of changes reaches maxEvents or
+// the amount of time since the last disk write reaches flushInterval.
+func (c *Checkpoint) run() {
+	defer c.wg.Done()
+
+	flushTimer := time.NewTimer(c.flushInterval)
+	defer flushTimer.Stop()
+loop:
+	for {
+		select {
+		case <-c.done:
+			break loop
+		case s := <-c.save:
+			c.lock.Lock()
+			c.states[s.Name] = s
+			c.lock.Unlock()
+			c.numUpdates++
+			if c.numUpdates < c.maxUpdates {
+				continue
+			}
+		case <-flushTimer.C:
+		}
+
+		c.persist()
+		flushTimer.Reset(c.flushInterval)
+	}
+
+	c.persist()
+}
+
+// Shutdown stops the checkpoint worker (which persists any state to disk as
+// it stops). This method blocks until the checkpoint worker shutdowns. Calling
+// this method more once is safe and has no effect.
+func (c *Checkpoint) Shutdown() {
+	c.once.Do(func() {
+		close(c.done)
+		c.wg.Wait()
+	})
+}
+
+// States returns the current in-memory event log state. This state information
+// is bootstrapped with any data found on disk at creation time.
+func (c *Checkpoint) States() map[string]EventLogState {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	copy := make(map[string]EventLogState)
+	for k, v := range c.states {
+		copy[k] = v
+	}
+
+	return copy
+}
+
+// Persist queues the given event log state information to be written to disk.
+func (c *Checkpoint) Persist(name string, recordNumber uint32, ts time.Time) {
+	c.save <- EventLogState{
+		Name:         name,
+		RecordNumber: recordNumber,
+		Timestamp:    ts,
+	}
+}
+
+// persist writes the current state to disk if the in-memory state is dirty.
+func (c *Checkpoint) persist() bool {
+	if c.numUpdates == 0 {
+		return false
+	}
+
+	err := c.flush()
+	if err != nil {
+		logp.Err("%v", err)
+		return false
+	}
+
+	logp.Debug("checkpoint", "Checkpoint saved to disk. numUpdates=%d",
+		c.numUpdates)
+	c.numUpdates = 0
+	return true
+}
+
+// flush writes the current state to disk.
+func (c *Checkpoint) flush() error {
+	tempFile := c.file + ".new"
+	file, err := os.Create(tempFile)
+	if err != nil {
+		return fmt.Errorf("Failed to flush state to disk. Could not open %s. %v",
+			tempFile, err)
+	}
+
+	// Sort persisted eventLogs by name.
+	c.sort = c.sort[:0]
+	for k := range c.states {
+		c.sort = append(c.sort, k)
+	}
+	sort.Strings(c.sort)
+
+	ps := PersistedState{
+		UpdateTime: time.Now().UTC(),
+		States:     make([]EventLogState, len(c.sort)),
+	}
+	for i, name := range c.sort {
+		ps.States[i] = c.states[name]
+	}
+
+	data, err := yaml.Marshal(ps)
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("Failed to flush state to disk. Could not marshal "+
+			"data to YAML. %v", err)
+	}
+
+	_, err = file.Write(data)
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("Failed to flush state to disk. Could not write to "+
+			"%s. %v", tempFile, err)
+	}
+
+	file.Close()
+	err = os.Rename(tempFile, c.file)
+	return err
+}
+
+// read loads the persisted state from disk. If the file does not exists then
+// the method returns nil and no error.
+func (c *Checkpoint) read() (*PersistedState, error) {
+	contents, err := ioutil.ReadFile(c.file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		}
+		return nil, err
+	}
+
+	ps := &PersistedState{}
+	err = yaml.Unmarshal(contents, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, nil
+}

--- a/checkpoint/checkpoint_test.go
+++ b/checkpoint/checkpoint_test.go
@@ -1,0 +1,75 @@
+package checkpoint_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/elastic/winlogbeat/checkpoint"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that a write is triggered when the maximum number of updates is reached.
+func TestWriteMaxUpdates(t *testing.T) {
+	dir, err := ioutil.TempDir("", "winlogbeat-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	file := filepath.Join(dir, "winlogbeat-test")
+	cp, err := checkpoint.NewCheckpoint(file, 2, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cp.Shutdown()
+
+	assert.False(t, fileExists(file))
+	cp.Persist("App", 1, time.Now())
+	time.Sleep(time.Second)
+	assert.False(t, fileExists(file))
+
+	cp.Persist("App", 2, time.Now())
+	time.Sleep(time.Second)
+	assert.True(t, fileExists(file))
+}
+
+// Test that a write is triggered when the maximum time period since the last
+// write is reached.
+func TestWriteTimedFlush(t *testing.T) {
+	dir, err := ioutil.TempDir("", "winlogbeat-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	file := filepath.Join(dir, "winlogbeat-test")
+	cp, err := checkpoint.NewCheckpoint(file, 100, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cp.Shutdown()
+
+	assert.False(t, fileExists(file))
+	cp.Persist("App", 1, time.Now())
+	time.Sleep(1500 * time.Millisecond)
+	assert.True(t, fileExists(file))
+}
+
+// fileExists returns true if the specified file exists.
+func fileExists(file string) bool {
+	_, err := os.Stat(file)
+	return !os.IsNotExist(err)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,10 @@ import (
 	"github.com/joeshaw/multierror"
 )
 
+const (
+	DefaultRegistryFile = ".winlogbeat.yaml"
+)
+
 type Validator interface {
 	Validate() error
 }
@@ -19,9 +23,10 @@ type ConfigSettings struct {
 }
 
 type WinlogbeatConfig struct {
-	IgnoreOlder string           `yaml:"ignore_older"`
-	EventLogs   []EventLogConfig `yaml:"event_logs"`
-	Metrics     MetricsConfig
+	IgnoreOlder  string           `yaml:"ignore_older"`
+	EventLogs    []EventLogConfig `yaml:"event_logs"`
+	Metrics      MetricsConfig    `yaml:"metrics"`
+	RegistryFile string           `yaml:"registry_file"`
 }
 
 // Validates the WinlogbeatConfig data and returns an error describing all

--- a/etc/winlogbeat.yml
+++ b/etc/winlogbeat.yml
@@ -1,6 +1,11 @@
 ###############################################################################
 ############################# Winlogbeat ######################################
 winlogbeat:
+  # The registry file is where Winlogbeat persists its state so that the beat
+  # can resume after shutdown or an outage. The default is .winlogbeat.yaml
+  # in the directory in which it was started.
+  registry_file: .winlogbeat.yaml
+
   # Filter events that are older than this amount of time. This value may be
   # overwritten on a per event_log basis. If omitted then no filtering will
   # occur unless ignore_older is specified with the individual event_log

--- a/eventlog/eventlog.go
+++ b/eventlog/eventlog.go
@@ -37,12 +37,15 @@ type EventLoggingAPI interface {
 type eventLog struct {
 	uncServerPath string       // UNC name of remote server.
 	name          string       // Name of the log that is opened.
-	recordNumber  uint32       // Last successfully read record number.
 	handle        Handle       // Handle to the event log.
 	readBuf       []byte       // Re-usable buffer for reading in events.
 	formatBuf     []byte       // Re-usable buffer for formatting messages.
 	handles       *handleCache // Cached mapping of source name to event message file handles.
 	logPrefix     string       // Prefix to add to all log entries.
+
+	recordNumber uint32 // First record number to read.
+	seek         bool   // Read should use seek.
+	ignoreFirst  bool   // Ignore first message returned from a read.
 }
 
 // Name returns the name of the event log (i.e. Application, Security, etc.).

--- a/eventlog/eventlog_integration_test.go
+++ b/eventlog/eventlog_integration_test.go
@@ -69,7 +69,7 @@ var oneTimeLogpInit sync.Once
 func configureLogp() {
 	oneTimeLogpInit.Do(func() {
 		if testing.Verbose() {
-			logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"eventlog"})
+			logp.LogInit(logp.LOG_DEBUG, "", false, true, []string{"eventlog", "eventlog_detail"})
 			logp.Info("DEBUG enabled for eventlog.")
 		} else {
 			logp.LogInit(logp.LOG_WARNING, "", false, true, []string{})
@@ -365,8 +365,16 @@ func TestOpenInvalidProvider(t *testing.T) {
 }
 
 // TODO: Add more test cases:
-// - Log rotation (clear log while reading)
-// - Record number rollover (there may not be an issue with this)
-// - Message that requires no string inserts.
-// - Reading from a source name instead of provider name.
-// - Resume reading from a given record number.
+// - Shall recover from errors caused by log rotation during a read. Based on the
+//   retention policy the log may be cleared when it reaches max size. See Retention:
+//   https://msdn.microsoft.com/en-us/library/windows/desktop/aa363648(v=vs.85).aspx
+// - Record number rollover (there may be an issue with this if ++ is used anywhere)
+// - Reading from a source name instead of provider name (can't be done according to docs).
+// - Persistent read mode shall support specifying a record number (or not specifying a record number).
+// -- Invalid record number based on range (should start at first record).
+// -- Invalid record number based on range timestamp match check (should start at first record).
+// -- Valid record number
+// --- Do not replay first record (it was already reported)
+// -- First read (no saved state) should return the first record (send first reported record).
+// - NewOnly read mode shall seek to end and ignore first.
+// - ReadThenExit read mode shall seek to end, read backwards, honor the EOF, then exit.

--- a/eventlog/syscall_windows.go
+++ b/eventlog/syscall_windows.go
@@ -54,6 +54,7 @@ func freeLibrary(handle Handle) error {
 //sys   formatMessage(flags uint32, source Handle, messageID uint32, languageID uint32, buffer *byte, bufferSize uint32, arguments *uintptr) (numChars uint32, err error) = kernel32.FormatMessageW
 //sys   _clearEventLog(eventLog Handle, backupFileName *uint16) (err error) = advapi32.ClearEventLogW
 //sys   _getNumberOfEventLogRecords(eventLog Handle, numberOfRecords *uint32) (err error) = advapi32.GetNumberOfEventLogRecords
+//sys   _getOldestEventLogRecord(eventLog Handle, oldestRecord *uint32) (err error) = advapi32.GetOldestEventLogRecord
 
 func clearEventLog(handle Handle, backupFileName string) error {
 	var name *uint16
@@ -76,4 +77,14 @@ func getNumberOfEventLogRecords(handle Handle) (uint32, error) {
 	}
 
 	return numRecords, nil
+}
+
+func getOldestEventLogRecord(handle Handle) (uint32, error) {
+	var oldestRecord uint32
+	err := _getOldestEventLogRecord(handle, &oldestRecord)
+	if err != nil {
+		return 0, err
+	}
+
+	return oldestRecord, nil
 }

--- a/eventlog/zsyscall_windows.go
+++ b/eventlog/zsyscall_windows.go
@@ -18,6 +18,7 @@ var (
 	procFormatMessageW             = modkernel32.NewProc("FormatMessageW")
 	procClearEventLogW             = modadvapi32.NewProc("ClearEventLogW")
 	procGetNumberOfEventLogRecords = modadvapi32.NewProc("GetNumberOfEventLogRecords")
+	procGetOldestEventLogRecord    = modadvapi32.NewProc("GetOldestEventLogRecord")
 )
 
 func openEventLog(uncServerName *uint16, sourceName *uint16) (handle Handle, err error) {
@@ -97,6 +98,18 @@ func _clearEventLog(eventLog Handle, backupFileName *uint16) (err error) {
 
 func _getNumberOfEventLogRecords(eventLog Handle, numberOfRecords *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall(procGetNumberOfEventLogRecords.Addr(), 2, uintptr(eventLog), uintptr(unsafe.Pointer(numberOfRecords)), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func _getOldestEventLogRecord(eventLog Handle, oldestRecord *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall(procGetOldestEventLogRecord.Addr(), 2, uintptr(eventLog), uintptr(unsafe.Pointer(oldestRecord)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
 			err = error(e1)


### PR DESCRIPTION
`Checkpoint` persists event log state information to disk so that event log monitoring can resume from the last read event in the case of a restart or unexpected interruption.